### PR TITLE
Fixed copyright notice in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2091 Alvin
+Copyright (c) 2019 Alvin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This reverts commit 0d5de036e283d8e5ac239952633f8282bd3f5c19, to make it less confusing and more legitimate in most jurisdictions, c.f. [the form of copyright notice required by the US copyright law, for instance](https://www.law.cornell.edu/uscode/text/17/401).
