### PR TITLE
Fix #32

### DIFF
--- a/base/unix/thread.h
+++ b/base/unix/thread.h
@@ -8,6 +8,7 @@
 #include <pthread.h>
 #include <assert.h>
 #include <memory>
+#include <unistd.h>
 #ifdef __linux__
 #include <sys/types.h>
 #endif


### PR DESCRIPTION
原理：
（不知道什么版本开始）unistd.h包含/usr/include/bits/unistd_ext.h （但是这个头文件不能直接包含）
其中声明了extern __pid_t gettid (void) __THROW;
注意，这里是extern声明，但是仍然有可能被thread.h的宏影响，所以我们可以采取先包含这个文件的方法来规避这个问题