### PR TITLE
Improve xmake.lua

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.xmake
+build
+lib

--- a/base/xmake.lua
+++ b/base/xmake.lua
@@ -1,22 +1,14 @@
 target("base")
     set_kind("static")
-    add_cxxflags("-std=c++11")
-    set_optimize("faster")  -- -O2
-    set_warnings("all")     -- -Wall
     set_targetdir("../lib")
+    add_includedirs("..", {interface = true})
     add_files("**.cc")
 
     if is_plat("macosx", "linux") then
-        --add_cxflags("-g3", "-Wno-narrowing", "-fPIC")
-        add_cxflags("-g3", "-Wno-narrowing")
-        if is_plat("macosx") then
-            add_cxflags("-fno-pie")
-        end
         add_files("co/context/context.S")
     end
 
     if is_plat("windows") then
-        add_cxflags("-Ox", "-fp:fast", "-EHsc")
         add_files("**.cpp")
         if is_arch("x64") then
             add_files("co/context/context_x64.asm")
@@ -25,6 +17,3 @@ target("base")
         end
     end
 
-    after_build(function ()
-        os.rm("build")
-    end)

--- a/rpcgen/xmake.lua
+++ b/rpcgen/xmake.lua
@@ -1,26 +1,6 @@
 target("rpcgen")
     set_kind("binary")
-    add_cxxflags("-std=c++11")
-    set_optimize("faster")  -- -O2
-    set_warnings("all")     -- -Wall
-    set_targetdir("../build")
-    add_includedirs("..")
-    add_linkdirs("../lib")
-    add_links("base")
+    add_deps("base")
     add_files("*.cc")
+    set_rundir("$(projectdir)")
 
-    if is_plat("macosx", "linux") then
-        add_cxflags("-g3")
-        if is_plat("macosx") then
-            add_cxflags("-fno-pie")
-        end
-        add_syslinks("pthread", "dl")
-    end
-
-    if is_plat("windows") then
-        add_cxflags("-Ox", "-fp:fast", "-EHsc")
-    end
-
-    after_build(function ()
-        os.rm("build")
-    end)

--- a/test/xmake.lua
+++ b/test/xmake.lua
@@ -1,61 +1,11 @@
-set_kind("binary")
-add_cxxflags("-std=c++11")
-set_optimize("faster")  -- -O2
-set_warnings("all")     -- -Wall
-set_targetdir("../build")
-add_includedirs("..")
-add_linkdirs("../lib")
---add_links("base", "jemalloc")
-add_links("base")
 
-after_build(function ()
-    os.rm("build")
-end)
-
-if is_plat("macosx", "linux") then
-    add_cxflags("-g3")
-    if is_plat("macosx") then
-        add_cxflags("-fno-pie")
-    end
-    add_syslinks("pthread", "dl")
+for _, test in ipairs({"co", "fast", "flag", "hash", 
+                    "json", "rapidjson", "log", "rpc", "str", "time", "tw", "xx"}) do
+target(test)
+    set_kind("binary")
+    set_default(false)
+    add_deps("base")
+--  add_links("jemalloc")
+    add_files(test .. "_test.cc")
 end
 
-if is_plat("windows") then
-    add_cxflags("-Ox", "-fp:fast", "-EHsc")
-end
-
-target("co")
-    add_files("co_test.cc")
-
-target("fast")
-    add_files("fast_test.cc")
-
-target("flag")
-    add_files("flag_test.cc")
-
-target("hash")
-    add_files("hash_test.cc")
-
-target("json")
-    add_files("json_test.cc")
-
-target("rapidjson")
-    add_files("rapidjson_test.cc")
-
-target("log")
-    add_files("log_test.cc")
-
-target("rpc")
-    add_files("rpc_test.cc")
-
-target("str")
-    add_files("str_test.cc")
-
-target("time")
-    add_files("time_test.cc")
-
-target("tw")
-    add_files("tw_test.cc")
-
-target("xx")
-    add_files("xx_test.cc")

--- a/unitest/base/xmake.lua
+++ b/unitest/base/xmake.lua
@@ -1,26 +1,6 @@
 target("unitest")
     set_kind("binary")
-    add_cxxflags("-std=c++11")
-    set_optimize("faster")  -- -O2
-    set_warnings("all")     -- -Wall
-    set_targetdir("../../build")
-    add_includedirs("../..")
-    add_linkdirs("../../lib")
-    add_links("base")
+    set_default(false)
+    add_deps("base")
     add_files("*.cc")
 
-    if is_plat("macosx", "linux") then
-        add_cxflags("-g3")
-        if is_plat("macosx") then
-            add_cxflags("-fno-pie")
-        end
-        add_syslinks("pthread", "dl")
-    end
-
-    if is_plat("windows") then
-        add_cxflags("-Ox", "-fp:fast", "-EHsc")
-    end
-
-    after_build(function ()
-        os.rm("build")
-    end)

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,0 +1,25 @@
+-- project
+set_project("co")
+
+-- set xmake minimum version
+set_xmakever("2.2.5")
+
+-- set common flags
+set_languages("c++11")
+set_optimize("faster")  -- -O2
+set_warnings("all")     -- -Wall
+
+if is_plat("macosx", "linux") then
+    add_cxflags("-g3")
+    if is_plat("macosx") then
+        add_cxflags("-fno-pie")
+    end
+    add_syslinks("pthread", "dl")
+end
+
+if is_plat("windows") then
+    add_cxflags("-Ox", "-fp:fast", "-EHsc")
+end
+
+-- include sub-projects
+includes("base", "rpcgen", "test", "unitest/base")


### PR DESCRIPTION
这边尝试对co里面xmake.lua的写法做了些改进，个人比较推荐的用法，只做参考，可以不用merge

1. 将所有通用的设置挪到了项目根xmake.lua
2. 通过includes关联所以子工程xmake.lua，不需要挨个进入子目录构建，这样容易在每个目录下产生buiild/.xmake目录，污染项目，还得额外的去删除
3. 通过add_deps，将test/unittest跟base做依赖关联，自动继承base里面的links, linkdirs和includedirs，不用额外设置

具体构建方式：

默认仅构建libbase和rpcgen，test/unittest通过set_default设置为默认不去构建，这块可自有调整

进入项目根目录执行：

```console
xmake
```

如果要构建unitest: 

```console
xmake build unittest
```

如果要构建test等bin

```console
xmake build flag
xmake build co
```

运行指定test程序

```console
xmake run flag
xmake run unittest
```

运行rpcgen处理proto  

```console
xmake run rpcgen .//test/rpc/hello_world.proto
```

强制构建所有：

```console
xmake -a/--all
```

强制运行所有

```console
xmake run -a/--all
```

所有操作都只需要在项目根目录下执行，避免每次都得切到不同子目录的繁琐流程，统一在项目根目录下生成build目录，即使不去删除也很方便管理，如果要删也可以自己os.rm下，或者xmake clean --all

另外base里面`set_targetdir("../lib")`我还是保留了，其实通过add_deps继承base依赖后，即使默认生成到build下，也没关系，其他bin都会自动找到对应的links和linkdirs 