### PR TITLE
Fix http request version and close connection as default while using http 1.0

### DIFF
--- a/include/co/so/http.h
+++ b/include/co/so/http.h
@@ -21,6 +21,7 @@ class Base {
     ~Base() = default;
 
     int version() const { return _version; }
+    void set_version(Version version) { _version = version; }
 
     const char* version_str() const {
         static const char* s[] = {

--- a/src/so/http.cc
+++ b/src/so/http.cc
@@ -93,6 +93,7 @@ void Server::on_connection(Connection* conn) {
             r = parse_req(*buf, pos, &req, &body_len);
             if (r != 0) {
                 fastring s;
+                // Use HTTP 1.1 when parse req failed.
                 s << "HTTP/1.1" << ' ' << r << ' ' << Res::status_str(r) << "\r\n";
                 s << "Content-Length: 0" << "\r\n";
                 s << "Connection: close" << "\r\n";
@@ -130,6 +131,8 @@ void Server::on_connection(Connection* conn) {
                 }
             } while (0);
         } while (0);
+
+        res.set_version(Version(req.version()));
 
         do {
             HTTPLOG << "http recv req: " << req.dbg();


### PR DESCRIPTION
## Issue description

1. Http Response always use HTTP 1.1 even if request using HTTP 1.0.
2. HTTP connection didn't close while using HTTP 1.0.