### PR TITLE
allow TaskSched run task immediately.

### DIFF
--- a/include/co/thread.h
+++ b/include/co/thread.h
@@ -18,6 +18,13 @@ class TaskSched {
         t._p = 0;
     }
 
+    // run f() immediately
+    void run(F&& f);
+
+    void run(const F& f) {
+        this->run(F(f));
+    }
+
     // run f() once @sec seconds later
     void run_in(F&& f, int sec);
 

--- a/src/thread.cc
+++ b/src/thread.cc
@@ -125,6 +125,14 @@ class TaskSchedImpl {
         this->stop();
     }
 
+    void run(F&& f) {
+        {
+            MutexGuard g(_mtx);
+            _tmp.push_back(new Task(std::move(f), 0, 0));
+        }
+        _ev.signal();
+    }
+
     void run_in(F&& f, int sec) {
         MutexGuard g(_mtx);
         _tmp.push_back(new Task(std::move(f), 0, sec));
@@ -235,6 +243,10 @@ TaskSched::~TaskSched() {
         delete (TaskSchedImpl*) _p;
         _p = 0;
     }
+}
+
+void TaskSched::run(F&& f) {
+    ((TaskSchedImpl*)_p)->run(std::move(f));
 }
 
 void TaskSched::run_in(F&& f, int sec) {


### PR DESCRIPTION
# Issue description

I just wanna task run without no delay. `TaskSched::run_in()` provides a delay, but if I set delay as 0, it's will still wait for about 1000ms to continue if it's block by `_ev.wait(1000)`.

So I add a method `run()`, it's will append task into the queue and notify blocked processes immediately.