### PR TITLE
Promote log time accuracy

### DIFF
--- a/include/co/log.h
+++ b/include/co/log.h
@@ -42,7 +42,7 @@ class LevelLogSaver {
         xxLog->clear();
 
         (*xxLog) << "DIWEF"[level];
-        xxLog->resize(14); // make room for time: 1108 18:16:08
+        xxLog->resize(21); // make room for time: 1108 18:16:08.123456
         (*xxLog) << ' ' << current_thread_id() << ' ' << file << ':' << line << ']' << ' ';
     }
 

--- a/src/win/time.cpp
+++ b/src/win/time.cpp
@@ -73,4 +73,46 @@ void sec(unsigned int n) {
 } // sleep
 } // ___
 
+
+struct timezone 
+{
+  int  tz_minuteswest; /* minutes W of Greenwich */
+  int  tz_dsttime;     /* type of dst correction */
+};
+
+int gettimeofday(struct timeval *tv, struct timezone *tz)
+{
+  FILETIME ft;
+  unsigned __int64 tmpres = 0;
+  static int tzflag = 0;
+
+  if (NULL != tv)
+  {
+    GetSystemTimeAsFileTime(&ft);
+
+    tmpres |= ft.dwHighDateTime;
+    tmpres <<= 32;
+    tmpres |= ft.dwLowDateTime;
+
+    tmpres /= 10;  /*convert into microseconds*/
+    /*converting file time to unix epoch*/
+    tmpres -= DELTA_EPOCH_IN_MICROSECS; 
+    tv->tv_sec = (long)(tmpres / 1000000UL);
+    tv->tv_usec = (long)(tmpres % 1000000UL);
+  }
+
+  if (NULL != tz)
+  {
+    if (!tzflag)
+    {
+      _tzset();
+      tzflag++;
+    }
+    tz->tz_minuteswest = _timezone / 60;
+    tz->tz_dsttime = _daylight;
+  }
+
+  return 0;
+}
+
 #endif


### PR DESCRIPTION
## Issue description

The current log time accuracy is not enough for server application, it's only print second in the output.

## Solution

I promote the time accuracy to microsecond. It's may be enough in many scenarios.
It's works on Linux as below, I didn't test it on Windows or macOS.

```
I0723 13:50:47.253280 17205 src/co/impl/scheduler.cc:207] coroutine schedulers start, sched num: 3, stack size: 1024k
I0723 13:50:47.253461 17205 src/so/http.cc:39] http server start, ip: 0.0.0.0, port: 8888
```