### PR TITLE
 在co::Mutex中增加用于Debug环境下的死锁警告 / Add deadlock timeout alert in coroutines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.1)
 project(co)
 
+if(CO_MUTEX_DEADLOCK_CHECK)
+    add_compile_options(-DCO_MUTEX_DEADLOCK_CHECK)
+endif()
+
 if(WIN32)
     if (NOT MSVC)
         message(FATAL_ERROR, "msvc required on windows")

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@
   - Support multi-thread scheduling, the default number of threads is the number of system CPU cores.
   - Coroutines share the thread stack (the default size is 1MB), and the memory footprint is extremely low, a single machine can easily create millions of coroutines.
   - Support system api hook (Linux & Mac).
-  - Support coroutine lock [co::Mutex](https://github.com/idealvin/co/blob/master/src/co/impl/co.cc).
+  - Support coroutine lock & deadlock alarm [co::Mutex](https://github.com/idealvin/co/blob/master/src/co/impl/co.cc).
   - Support coroutine synchronization event [co::Event](https://github.com/idealvin/co/blob/master/src/co/impl/co.cc).
   - Support coroutine pool [co::Pool](https://github.com/idealvin/co/blob/master/src/co/impl/co.cc).
 

--- a/readme_cn.md
+++ b/readme_cn.md
@@ -19,7 +19,7 @@
   - 支持多线程调度，默认线程数为系统 CPU 核数.
   - 协程共享线程栈(默认大小为 1MB)，内存占用极低，单机可轻松创建数百万协程.
   - 支持系统 api hook (Linux & Mac).
-  - 支持协程锁 [co::Mutex](https://github.com/idealvin/co/blob/master/src/co/impl/co.cc).
+  - 支持协程锁与死锁警告 [co::Mutex](https://github.com/idealvin/co/blob/master/src/co/impl/co.cc).
   - 支持协程同步事件 [co::Event](https://github.com/idealvin/co/blob/master/src/co/impl/co.cc).
   - 支持协程池 [co::Pool](https://github.com/idealvin/co/blob/master/src/co/impl/co.cc).
 


### PR DESCRIPTION
因为觉得这个feature看起来还不错所以实现了一下，当某个线程调用lock()后超过60s没有调用unlock()将会触发每五秒一条的Error log，类似于 github.com/sasha-s/go-deadlock 的核心特性

当使用cmake .. -DCO_MUTEX_DEADLOCK_CHECK 即可启用这个特性

【其实是因为我不会写xmake也不知道怎么弄vs那些所以就cmake凑合一下了】